### PR TITLE
copied select column panel feature folder from external branch

### DIFF
--- a/app/cdap/components/WranglerGrid/SelectColumnPanel/ColumnsList/__test__/SelectColumnsList.test.tsx
+++ b/app/cdap/components/WranglerGrid/SelectColumnPanel/ColumnsList/__test__/SelectColumnsList.test.tsx
@@ -1,0 +1,156 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import { fireEvent, render, screen } from '@testing-library/react';
+import history from 'services/history';
+import React from 'react';
+import { Route, Router, Switch } from 'react-router';
+import SelectColumnsList from 'components/WranglerGrid/SelectColumnPanel/ColumnsList';
+
+describe('It should test the SelectColumnsList Component', () => {
+  it('should render the SelectColumnsList Component', () => {
+    render(
+      <Router history={history}>
+        <Switch>
+          <Route>
+            <SelectColumnsList
+              selectedColumnsCount={1}
+              setSelectedColumns={() => jest.fn()}
+              dataQuality={[]}
+              transformationDataType={[]}
+              columnsList={[]}
+              transformationName={''}
+              selectedColumns={[]}
+              filteredColumnsOnTransformationType={[
+                { label: 'hello', type: ['test'], name: 'hello' },
+                { label: 'hello', type: ['test'], name: 'hello' },
+              ]}
+              isSingleSelection={false}
+            />
+          </Route>
+        </Switch>
+      </Router>
+    );
+    expect(screen.getByTestId(/select-column-list-parent/i)).toBeInTheDocument();
+  });
+  it('should trigger foucus function and focus the input element as expected ', () => {
+    const mockSetSelected = jest.fn();
+    render(
+      <Router history={history}>
+        <Switch>
+          <Route>
+            <SelectColumnsList
+              columnsList={[]}
+              selectedColumnsCount={0}
+              setSelectedColumns={mockSetSelected}
+              dataQuality={[
+                { label: 'hello', value: '' },
+                { label: 'world', value: '' },
+              ]}
+              transformationDataType={['all', 'test']}
+              transformationName={''}
+              selectedColumns={[]}
+              filteredColumnsOnTransformationType={[
+                { label: 'hello', type: ['test'], name: 'hello' },
+                { label: 'hello', type: ['test'], name: 'hello' },
+              ]}
+              isSingleSelection={false}
+            />
+          </Route>
+        </Switch>
+      </Router>
+    );
+
+    const searchIconElement = screen.getByTestId(/click-handle-focus/i);
+    const inputElement = screen.getByTestId(/input-search-id/i);
+    expect(inputElement).not.toHaveFocus();
+    fireEvent.click(searchIconElement);
+    expect(inputElement).toHaveFocus();
+  });
+
+  it('should render the SelectColumnsList Component while changing text input with some input value ', () => {
+    const getSelectedColumns = jest.fn();
+    render(
+      <Router history={history}>
+        <Switch>
+          <Route>
+            <SelectColumnsList
+              columnsList={[]}
+              selectedColumnsCount={0}
+              setSelectedColumns={getSelectedColumns}
+              dataQuality={[
+                { label: 'hello', value: '' },
+                { label: 'world', value: '' },
+              ]}
+              transformationDataType={['all', 'test']}
+              transformationName={''}
+              selectedColumns={[]}
+              filteredColumnsOnTransformationType={[
+                { label: 'hello', type: ['test'], name: 'hello' },
+                { label: 'hello', type: ['test'], name: 'hello' },
+              ]}
+              isSingleSelection={false}
+            />
+          </Route>
+        </Switch>
+      </Router>
+    );
+
+    const inputSearchElement = screen.getByTestId('input-search-id');
+    fireEvent.change(inputSearchElement, { target: { value: '123' } });
+    expect(inputSearchElement).toHaveValue('123');
+    fireEvent.change(inputSearchElement, { target: { value: '' } });
+    expect(inputSearchElement).toHaveTextContent('');
+  });
+
+  it('should render the SelectColumnsList Component with selectedColumnsCount is 0 and data quality array and trigger the multiple selection function', () => {
+    const mockSetSelected = jest.fn();
+    render(
+      <Router history={history}>
+        <Switch>
+          <Route>
+            <SelectColumnsList
+              selectedColumnsCount={0}
+              columnsList={[
+                { label: 'hello', type: ['a', 'b'], name: 'test' },
+                { label: 'hello', type: ['a', 'b'], name: 'test' },
+              ]}
+              setSelectedColumns={mockSetSelected}
+              dataQuality={[
+                { label: 'hello', value: '' },
+                { label: 'world', value: '' },
+              ]}
+              transformationDataType={['TEST', 'all']}
+              transformationName={'join-columns'}
+              selectedColumns={[
+                { label: 'hello', type: ['test'], name: 'hello' },
+                { label: 'hello', type: ['test'], name: 'hello' },
+              ]}
+              filteredColumnsOnTransformationType={[
+                { label: 'hello', type: ['test'], name: 'hello' },
+                { label: 'hello', type: ['test'], name: 'hello' },
+              ]}
+              isSingleSelection={false}
+            />
+          </Route>
+        </Switch>
+      </Router>
+    );
+    const checkboxInputElement = screen.getAllByTestId('check-box-input-0');
+    fireEvent.change(checkboxInputElement[0], { target: { checked: true } });
+    expect(checkboxInputElement[0]).toHaveProperty('checked', true);
+  });
+});

--- a/app/cdap/components/WranglerGrid/SelectColumnPanel/ColumnsList/index.tsx
+++ b/app/cdap/components/WranglerGrid/SelectColumnPanel/ColumnsList/index.tsx
@@ -1,0 +1,148 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import React, { ChangeEvent, useEffect, useRef, useState } from 'react';
+import { NoDataSVG } from 'components/GridTable/iconStore';
+import T from 'i18n-react';
+import { IColumnsListProps } from 'components/WranglerGrid/SelectColumnPanel/ColumnsList/types';
+import { IHeaderNamesList } from 'components/WranglerGrid/SelectColumnPanel/types';
+import DataTable from 'components/WranglerGrid/SelectColumnPanel/DataTable';
+import { MULTI_SELECTION_COLUMN } from 'components/WranglerGrid/SelectColumnPanel/constants';
+import CountWidget from 'components/WranglerGrid/SelectColumnPanel/CountWidget';
+import { IMultipleSelectedFunctionDetail } from 'components/WranglerGrid/SelectColumnPanel/types';
+import { SELECT_COLUMN_LIST_PREFIX } from 'components/WranglerGrid/SelectColumnPanel/constants';
+import { NormalFont, SubHeadBoldFont } from 'components/common/TypographyText';
+import {
+  ColumnWrapper,
+  CenterAlignBox,
+  FlexWrapper,
+  ColumnInnerWrapper,
+  SearchWrapper,
+  StyledSearchIcon,
+  SearchInputField,
+  SearchIconButton,
+} from 'components/WranglerGrid/SelectColumnPanel/ColumnsList/styles';
+
+export default function({
+  transformationDataType,
+  selectedColumnsCount,
+  columnsList,
+  setSelectedColumns,
+  dataQuality,
+  transformationName,
+  selectedColumns,
+  filteredColumnsOnTransformationType,
+  isSingleSelection,
+}: IColumnsListProps) {
+  const [columns, setColumns] = useState(columnsList);
+  const ref = useRef(null);
+
+  useEffect(() => {
+    setColumns(filteredColumnsOnTransformationType);
+  }, []);
+
+  // This function is used to handle multiple column selection
+  const handleMultipleSelection = (
+    event: ChangeEvent<HTMLInputElement>,
+    column: IHeaderNamesList
+  ) => {
+    if (event.target.checked) {
+      setSelectedColumns([...selectedColumns, column]);
+    } else {
+      const indexOfUnchecked = selectedColumns.findIndex(
+        (columnDetail) => columnDetail.label === column.label
+      );
+      indexOfUnchecked > -1 &&
+        setSelectedColumns(() => selectedColumns.filter((_, index) => index !== indexOfUnchecked));
+    }
+  };
+
+  // This function is used to disable checkbox when the selection limit is reached for e.g. in join and swap we can select only two column
+  const handleDisableCheckbox = () => {
+    const multiSelect = MULTI_SELECTION_COLUMN.findIndex(
+      (functionDetail: IMultipleSelectedFunctionDetail) =>
+        functionDetail.value === transformationName && functionDetail.isMoreThanTwo
+    );
+    if (selectedColumns.length < 2 || multiSelect > -1) {
+      return false;
+    }
+    return true;
+  };
+
+  // This function is used to search a column by it's name from the column list
+  const handleSearch = (event: ChangeEvent<HTMLInputElement>) => {
+    if (event.target.value) {
+      let columnValue: IHeaderNamesList[] = [];
+      if (filteredColumnsOnTransformationType.length) {
+        columnValue = filteredColumnsOnTransformationType.filter((columnDetail: IHeaderNamesList) =>
+          columnDetail.label.toLowerCase().includes(event.target.value.toLowerCase())
+        );
+      }
+      setColumns(columnValue);
+    } else {
+      setColumns(filteredColumnsOnTransformationType);
+    }
+  };
+
+  // This function is used to focus input field when a search icon is clicked
+  const handleFocus = () => {
+    ref?.current?.focus();
+  };
+
+  return (
+    <ColumnWrapper data-testid="select-column-list-parent">
+      {filteredColumnsOnTransformationType.length === 0 && (
+        <FlexWrapper>
+          <CenterAlignBox>
+            {NoDataSVG}
+            <SubHeadBoldFont component="p" data-testid="no-column-title">
+              {T.translate(`${SELECT_COLUMN_LIST_PREFIX}.noColumns`)}
+            </SubHeadBoldFont>
+            <NormalFont component="p" data-testid="no-column-subTitle">
+              {T.translate(`${SELECT_COLUMN_LIST_PREFIX}.noMatchColumnDatatype`)}
+            </NormalFont>
+          </CenterAlignBox>
+        </FlexWrapper>
+      )}
+      {filteredColumnsOnTransformationType.length > 0 && (
+        <>
+          <ColumnInnerWrapper>
+            <CountWidget selectedColumnsCount={selectedColumnsCount} />
+            <SearchWrapper>
+              <SearchInputField data-testid="input-search-id" onChange={handleSearch} ref={ref} />
+              <SearchIconButton onClick={handleFocus} data-testid="click-handle-focus">
+                <StyledSearchIcon />
+              </SearchIconButton>
+            </SearchWrapper>
+          </ColumnInnerWrapper>
+          <DataTable
+            dataQualityValue={dataQuality}
+            handleSingleSelection={(column) => setSelectedColumns([column])}
+            handleDisableCheckbox={handleDisableCheckbox}
+            handleMultipleSelection={handleMultipleSelection}
+            columns={filteredColumnsOnTransformationType.length === 0 ? [] : columns}
+            transformationDataType={transformationDataType}
+            isSingleSelection={isSingleSelection}
+            selectedColumns={selectedColumns}
+            totalColumnCount={filteredColumnsOnTransformationType.length}
+            setSelectedColumns={setSelectedColumns}
+            transformationName={transformationName}
+          />
+        </>
+      )}
+    </ColumnWrapper>
+  );
+}

--- a/app/cdap/components/WranglerGrid/SelectColumnPanel/ColumnsList/styles.ts
+++ b/app/cdap/components/WranglerGrid/SelectColumnPanel/ColumnsList/styles.ts
@@ -1,0 +1,75 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import styled from 'styled-components';
+import { grey } from '@material-ui/core/colors';
+import { Box, IconButton } from '@material-ui/core';
+import SearchIcon from '@material-ui/icons/Search';
+
+export const ColumnWrapper = styled(Box)`
+  height: 90%;
+`;
+
+export const ColumnInnerWrapper = styled(Box)`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-top: 10px;
+`;
+
+export const CenterAlignBox = styled(Box)`
+  text-align: center;
+`;
+
+export const FlexWrapper = styled(Box)`
+  display: flex;
+  height: 100%;
+  align-items: center;
+`;
+
+export const SearchWrapper = styled(Box)`
+  position: relative;
+  display: flex;
+`;
+
+export const SearchIconButton = styled(IconButton)`
+  padding: 5px 0px 5px 5px;
+
+  &.MuiIconButton-root:hover {
+    background-color: transparent;
+  }
+  & .MuiTouchRipple-root {
+    display: none;
+  }
+`;
+
+export const StyledSearchIcon = styled(SearchIcon)`
+  &.MuiSvgIcon-root {
+    width: 24px;
+    height: 24px;
+  }
+`;
+
+export const SearchInputField = styled.input`
+  margin-right: 5px;
+  border: none;
+  border-bottom: 1px solid transparent;
+  margin-bottom: 5px;
+  &:focus {
+    border-bottom: 1px solid ${grey[700]};
+    outline: none;
+  }
+`;

--- a/app/cdap/components/WranglerGrid/SelectColumnPanel/ColumnsList/types.ts
+++ b/app/cdap/components/WranglerGrid/SelectColumnPanel/ColumnsList/types.ts
@@ -1,0 +1,30 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import { IHeaderNamesList } from 'components/WranglerGrid/SelectColumnPanel/types';
+import { Dispatch, SetStateAction } from 'react';
+
+export interface IColumnsListProps {
+  transformationDataType: string[];
+  selectedColumnsCount: number;
+  columnsList: IHeaderNamesList[];
+  setSelectedColumns: Dispatch<SetStateAction<IHeaderNamesList[]>>;
+  dataQuality: Array<Record<string, string | number>>;
+  transformationName: string;
+  selectedColumns: IHeaderNamesList[];
+  filteredColumnsOnTransformationType: IHeaderNamesList[];
+  isSingleSelection: boolean;
+}

--- a/app/cdap/components/WranglerGrid/SelectColumnPanel/CountWidget/__test__/SelectedColumnCountWidget.test.tsx
+++ b/app/cdap/components/WranglerGrid/SelectColumnPanel/CountWidget/__test__/SelectedColumnCountWidget.test.tsx
@@ -1,0 +1,29 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import CountWidget from 'components/WranglerGrid/SelectColumnPanel/CountWidget';
+import T from 'i18n-react';
+
+describe('It should test the SelectColumnsList Component', () => {
+  it('should render the SelectColumnsList Component with no selectedColumnsCount', () => {
+    render(<CountWidget selectedColumnsCount={0} />);
+    expect(screen.getByTestId(/no-column-title/i)).toHaveTextContent(
+      `${T.translate('features.WranglerNewUI.GridPage.selectColumnListPanel.noColumnSelected')}`
+    );
+  });
+});

--- a/app/cdap/components/WranglerGrid/SelectColumnPanel/CountWidget/index.tsx
+++ b/app/cdap/components/WranglerGrid/SelectColumnPanel/CountWidget/index.tsx
@@ -1,0 +1,38 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import React from 'react';
+import T from 'i18n-react';
+import { SELECT_COLUMN_LIST_PREFIX } from 'components/WranglerGrid/SelectColumnPanel/constants';
+import { NormalFont } from 'components/common/TypographyText';
+
+export default function({ selectedColumnsCount }: { selectedColumnsCount: number }) {
+  const getDisplayText = () => {
+    if (selectedColumnsCount > 0) {
+      return T.translate(`${SELECT_COLUMN_LIST_PREFIX}.columnsSelected`, {
+        selectedColumnsCount,
+      });
+    }
+    return `${T.translate(`${SELECT_COLUMN_LIST_PREFIX}.noColumnSelected`)}`;
+  };
+  const text = getDisplayText();
+
+  return (
+    <NormalFont component="p" data-testid="no-column-title">
+      {text}
+    </NormalFont>
+  );
+}

--- a/app/cdap/components/WranglerGrid/SelectColumnPanel/DataTable/InputWidgets/__test__/InputWidgets.test.tsx
+++ b/app/cdap/components/WranglerGrid/SelectColumnPanel/DataTable/InputWidgets/__test__/InputWidgets.test.tsx
@@ -1,0 +1,86 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import { fireEvent, render, screen } from '@testing-library/react';
+import React, { ChangeEvent } from 'react';
+import InputWidgets from 'components/WranglerGrid/SelectColumnPanel/DataTable/InputWidgets';
+
+const mockColumnList = [
+  { name: 'body_1', type: ['all'], label: 'body_1' },
+  { name: 'body_2', type: ['all'], label: 'body_2' },
+  { name: 'body_3', type: ['all'], label: 'body_3' },
+  { name: 'body_4', type: ['string'], label: 'body_4' },
+  { name: 'body_5', type: ['int'], label: 'body_5' },
+];
+
+describe('It should render ', () => {
+  it('Should render component with isSingleSelection false and disable checkbox is false', () => {
+    render(
+      <InputWidgets
+        isSingleSelection={false}
+        selectedColumns={[
+          { name: 'body_2', type: ['all'], label: 'body_2' },
+          { name: 'body_1', type: ['all'], label: 'body_1' },
+        ]}
+        handleSingleSelection={() => jest.fn()}
+        columnDetail={{ name: 'body_2', type: ['all'], label: 'body_2' }}
+        handleDisableCheckbox={() => false}
+        handleMultipleSelection={() => jest.fn()}
+        columnIndex={0}
+      />
+    );
+    const checkBoxElement = screen.getByTestId(/check-box-input-0/i);
+    fireEvent.change(checkBoxElement, { target: { checked: true } });
+    expect(screen.getByTestId(/form-control-label-parent-0/i)).toBeInTheDocument();
+  });
+
+  it('Should render component with isSingleSelection false and disable checkbox is true', () => {
+    render(
+      <InputWidgets
+        isSingleSelection={false}
+        selectedColumns={[
+          { name: 'body_2', type: ['all'], label: 'body_2' },
+          { name: 'body_1', type: ['all'], label: 'body_1' },
+        ]}
+        handleSingleSelection={() => jest.fn()}
+        columnDetail={{ name: 'body_2', type: ['all'], label: 'body_2' }}
+        handleDisableCheckbox={() => true}
+        handleMultipleSelection={() => jest.fn()}
+        columnIndex={0}
+      />
+    );
+    const checkBoxElement = screen.getByTestId(/check-box-input-0/i);
+    fireEvent.change(checkBoxElement, { target: { checked: true } });
+    expect(screen.getByTestId(/form-control-label-parent-0/i)).toBeInTheDocument();
+  });
+
+  it('Should render component with isSingleSelection true', () => {
+    render(
+      <InputWidgets
+        isSingleSelection={true}
+        selectedColumns={[{ name: 'body_2', type: ['all'], label: 'body_2' }]}
+        handleSingleSelection={() => jest.fn()}
+        columnDetail={{ name: 'body_2', type: ['all'], label: 'body_2' }}
+        handleDisableCheckbox={() => false}
+        handleMultipleSelection={() => jest.fn()}
+        columnIndex={0}
+      />
+    );
+    const radioInputElement = screen.getByTestId(/radio-input-0/i);
+    fireEvent.change(radioInputElement, { target: { checked: true } });
+    expect(screen.getByTestId(/radio-input-0/i)).toBeInTheDocument();
+  });
+});

--- a/app/cdap/components/WranglerGrid/SelectColumnPanel/DataTable/InputWidgets/index.tsx
+++ b/app/cdap/components/WranglerGrid/SelectColumnPanel/DataTable/InputWidgets/index.tsx
@@ -1,0 +1,82 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import React, { ChangeEvent } from 'react';
+import { IInputWidgetsProps } from 'components/WranglerGrid/SelectColumnPanel/DataTable/types';
+import { Checkbox, FormControlLabel, Radio } from '@material-ui/core';
+import styled from 'styled-components';
+
+const RadioInput = styled(Radio)`
+  &.MuiRadio-root {
+    padding: 0;
+  }
+`;
+
+export default function({
+  isSingleSelection,
+  selectedColumns,
+  handleSingleSelection,
+  columnDetail,
+  handleDisableCheckbox,
+  handleMultipleSelection,
+  columnIndex,
+}: IInputWidgetsProps) {
+  const getDisableAttributeValue = () =>
+    selectedColumns.findIndex((column) => column.label === columnDetail.label) > -1 ||
+    !handleDisableCheckbox()
+      ? false
+      : true;
+
+  const getCheckedAttributeValue = () =>
+    selectedColumns.length &&
+    selectedColumns.findIndex((column) => column.label === columnDetail.label) > -1
+      ? true
+      : false;
+
+  const disabledInputElement = getDisableAttributeValue();
+
+  const checkedInputElement = getCheckedAttributeValue();
+
+  const onRadioInputChange = () => handleSingleSelection(columnDetail);
+  const onCheckBoxInputChange = (event) => handleMultipleSelection(event, columnDetail);
+
+  if (isSingleSelection) {
+    return (
+      <RadioInput
+        color="primary"
+        onChange={onRadioInputChange}
+        checked={checkedInputElement}
+        data-testid={`radio-input-${columnIndex}`}
+      />
+    );
+  } else {
+    return (
+      <FormControlLabel
+        disabled={disabledInputElement}
+        control={
+          <Checkbox
+            color="primary"
+            checked={checkedInputElement}
+            onChange={onCheckBoxInputChange}
+            data-testid={`check-box-input-${columnIndex}`}
+          />
+        }
+        label={''}
+        data-testid={`form-control-label-parent-${columnIndex}`}
+      />
+    );
+  }
+}

--- a/app/cdap/components/WranglerGrid/SelectColumnPanel/DataTable/TableRowWidget/index.tsx
+++ b/app/cdap/components/WranglerGrid/SelectColumnPanel/DataTable/TableRowWidget/index.tsx
@@ -1,0 +1,81 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import React from 'react';
+import InputWidgets from 'components/WranglerGrid/SelectColumnPanel/DataTable/InputWidgets';
+import DataQualityCircularProgressBar from 'components/common/DataQualityCircularProgressBar';
+import { ITableRowWidgetProps } from 'components/WranglerGrid/SelectColumnPanel/DataTable/types';
+import { TableCellText } from 'components/common/TypographyText';
+import { TableCell } from '@material-ui/core';
+import { grey } from '@material-ui/core/colors';
+import styled from 'styled-components';
+import { StyledTableRow } from 'components/WranglerGrid/SelectColumnPanel/DataTable';
+
+const StyledTableBodyCell = styled(TableCell)`
+  &.MuiTableCell-body {
+    font-weight: 400;
+    font-size: 16px;
+    line-height: 150%;
+    letter-spacing: 0.15px;
+    color: ${grey[700]};
+    padding: 5px;
+    height: 64px;
+  }
+`;
+
+const StyledInputTableBodyCell = styled(StyledTableBodyCell)`
+  &.MuiTableCell-body {
+    padding-left: 11px;
+  }
+`;
+
+export default function({
+  handleSingleSelection,
+  selectedColumns,
+  dataQualityValue,
+  isSingleSelection,
+  handleDisableCheckbox,
+  handleMultipleSelection,
+  columnIndex,
+  columnDetail,
+}: ITableRowWidgetProps) {
+  return (
+    <StyledTableRow key={`column-${columnIndex}`}>
+      <StyledInputTableBodyCell>
+        <InputWidgets
+          isSingleSelection={isSingleSelection}
+          selectedColumns={selectedColumns}
+          handleSingleSelection={handleSingleSelection}
+          columnDetail={columnDetail}
+          handleDisableCheckbox={handleDisableCheckbox}
+          handleMultipleSelection={handleMultipleSelection}
+          columnIndex={columnIndex}
+        />
+      </StyledInputTableBodyCell>
+      <StyledTableBodyCell>
+        <TableCellText component="div">{columnDetail.label}</TableCellText>
+        <TableCellText component="div">{columnDetail.type}</TableCellText>
+      </StyledTableBodyCell>
+      <StyledTableBodyCell>
+        {dataQualityValue.length && (
+          <DataQualityCircularProgressBar
+            dataQualityPercentValue={parseInt(dataQualityValue[columnIndex].value.toString())}
+          />
+        )}
+      </StyledTableBodyCell>
+    </StyledTableRow>
+  );
+}

--- a/app/cdap/components/WranglerGrid/SelectColumnPanel/DataTable/__tests__/ColumnTable.test.tsx
+++ b/app/cdap/components/WranglerGrid/SelectColumnPanel/DataTable/__tests__/ColumnTable.test.tsx
@@ -1,0 +1,107 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import { fireEvent, render, screen } from '@testing-library/react';
+import React from 'react';
+import DataTable from 'components/WranglerGrid/SelectColumnPanel/DataTable';
+import T from 'i18n-react';
+
+const mockColumnList = [
+  { name: 'body_1', type: ['all'], label: 'body_1' },
+  { name: 'body_2', type: ['all'], label: 'body_2' },
+  { name: 'body_3', type: ['all'], label: 'body_3' },
+  { name: 'body_4', type: ['string'], label: 'body_4' },
+  { name: 'body_5', type: ['int'], label: 'body_5' },
+];
+
+describe('It should test DataTable Component', () => {
+  const mockSetSelected = jest.fn();
+
+  it('Should render the DataTable Component checking its table head named Columns', () => {
+    render(
+      <DataTable
+        columns={mockColumnList}
+        transformationDataType={['all']}
+        handleSingleSelection={() => jest.fn()}
+        selectedColumns={[]}
+        dataQualityValue={[]}
+        isSingleSelection={false}
+        handleDisableCheckbox={() => false}
+        handleMultipleSelection={() => jest.fn()}
+        totalColumnCount={5}
+        setSelectedColumns={mockSetSelected}
+        transformationName={'swap-columns'}
+      />
+    );
+    const checkBoxElement = screen.getByTestId(/column-table-check-box/i);
+    fireEvent.change(checkBoxElement, { target: { checked: true } });
+    expect(checkBoxElement).toHaveProperty('checked', true);
+    expect(screen.getByTestId(/panel-columns/i)).toHaveTextContent(
+      `${T.translate('features.WranglerNewUI.GridPage.addTransformationPanel.columns')}`
+    );
+  });
+
+  it('Should render the DataTable Component checking its table head named Null Values', () => {
+    render(
+      <DataTable
+        columns={mockColumnList}
+        transformationDataType={['all']}
+        handleSingleSelection={() => jest.fn()}
+        selectedColumns={[]}
+        dataQualityValue={[]}
+        isSingleSelection={false}
+        handleDisableCheckbox={() => false}
+        handleMultipleSelection={() => jest.fn()}
+        totalColumnCount={0}
+        setSelectedColumns={mockSetSelected}
+        transformationName={'swap-columns'}
+      />
+    );
+    const checkBoxElement = screen.getByTestId(/column-table-check-box/i);
+    fireEvent.change(checkBoxElement, { target: { checked: true } });
+    expect(checkBoxElement).toHaveProperty('checked', true);
+    expect(screen.getByTestId(/panel-values/i)).toHaveTextContent(
+      `${T.translate('features.WranglerNewUI.GridPage.addTransformationPanel.nullValues')}`
+    );
+  });
+
+  it('Should trigger the checkboxs handleChange when colums length is greater than 2', () => {
+    const selectedColumns = [
+      { name: 'body_1', type: ['all'], label: 'body_1' },
+      { name: 'body_2', type: ['all'], label: 'body_2' },
+    ];
+    render(
+      <DataTable
+        columns={mockColumnList}
+        transformationDataType={['all']}
+        handleSingleSelection={() => jest.fn()}
+        selectedColumns={selectedColumns}
+        dataQualityValue={[]}
+        isSingleSelection={false}
+        handleDisableCheckbox={() => false}
+        handleMultipleSelection={() => jest.fn()}
+        totalColumnCount={0}
+        setSelectedColumns={mockSetSelected}
+        transformationName={'swap-columns'}
+      />
+    );
+    const checkBoxElement = screen.getByTestId(/column-table-check-box/i);
+    fireEvent.change(checkBoxElement, { target: { checked: true } });
+    expect(checkBoxElement).toHaveProperty('checked', true);
+    fireEvent.change(checkBoxElement, { target: { checked: false } });
+    expect(checkBoxElement).toHaveProperty('checked', false);
+  });
+});

--- a/app/cdap/components/WranglerGrid/SelectColumnPanel/DataTable/index.tsx
+++ b/app/cdap/components/WranglerGrid/SelectColumnPanel/DataTable/index.tsx
@@ -1,0 +1,193 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import { TableBody, Checkbox, Divider, Box } from '@material-ui/core';
+import React from 'react';
+import T from 'i18n-react';
+import TableRowWidget from 'components/WranglerGrid/SelectColumnPanel/DataTable/TableRowWidget';
+import { IDataTableProps } from 'components/WranglerGrid/SelectColumnPanel/DataTable/types';
+import {
+  ADD_TRANSFORMATION_PREFIX,
+  SELECT_COLUMN_LIST_PREFIX,
+} from 'components/WranglerGrid/SelectColumnPanel/constants';
+import { MULTI_SELECTION_COLUMN } from 'components/WranglerGrid/SelectColumnPanel/constants';
+import { TableContainer, Table, TableHead, TableRow, TableCell } from '@material-ui/core';
+import { grey } from '@material-ui/core/colors';
+import styled, { css } from 'styled-components';
+import { NormalFont, SubHeadBoldFont } from 'components/common/TypographyText';
+import { NoDataSVG } from 'components/GridTable/iconStore';
+import { IHeaderNamesList } from 'components/WranglerGrid/SelectColumnPanel/types';
+
+const cellFontCSS = css`
+  font-weight: 400;
+  font-size: 16px;
+  line-height: 150%;
+  letter-spacing: 0.15px;
+`;
+
+const CenterAlignWrapper = styled(Box)`
+  text-align: center;
+`;
+
+const FlexWrapper = styled(Box)`
+  display: flex;
+  height: 100%;
+  align-items: center;
+`;
+
+export const StyledTableRow = styled(TableRow)`
+  ${cellFontCSS}
+  color: ${grey[700]};
+  display: grid;
+  grid-template-columns: 8% 45% 45%;
+  align-items: center;
+  height: 100%;
+`;
+
+const StyledTableContainer = styled(TableContainer)`
+  height: 100%;
+`;
+
+const StyledTable = styled(Table)`
+  display: flex;
+  flex-direction: column;
+`;
+
+const StyledTableHead = styled(TableHead)`
+  height: 54px;
+`;
+
+const StyledTableHeadCell = styled(TableCell)`
+  &.MuiTableCell-head {
+    ${cellFontCSS}
+    padding: 0;
+    color: ${grey[900]};
+    border-bottom: none !important;
+  }
+`;
+
+export default function({
+  columns,
+  transformationDataType,
+  handleSingleSelection,
+  selectedColumns,
+  dataQualityValue,
+  isSingleSelection,
+  handleDisableCheckbox,
+  handleMultipleSelection,
+  setSelectedColumns,
+  transformationName,
+}: IDataTableProps) {
+  const indexOfMultiSelectOption = MULTI_SELECTION_COLUMN.findIndex(
+    (option) => option.value === transformationName && option.isMoreThanTwo === false
+  );
+
+  // This function is used to either select all checkbox or uncheck the selected once
+  const handleChange = () => {
+    if (indexOfMultiSelectOption > -1) {
+      // If only two column selection is possible
+      if (selectedColumns.length) {
+        setSelectedColumns([]); // If columns are already selected then those all will be unchecked
+      } else {
+        if (columns.length > 2) {
+          setSelectedColumns(columns.slice(0, 2)); // When clicked on a checkbox then first two column will be selected in case if transformation present is join/swap
+        } else {
+          setSelectedColumns(columns); // When clicked on a checkbox then all columns will be selected
+        }
+      }
+    } else {
+      if (selectedColumns.length) {
+        setSelectedColumns([]); // If columns are already selected then those all will be unchecked
+      } else {
+        setSelectedColumns(columns); // When clicked on a checkbox then all columns will be selected
+      }
+    }
+  };
+
+  // This function is used to filter column based on their datatype which matches with the supported types of transformation to be applied
+  const getColumnsToDisplay = () => {
+    if (transformationDataType.includes('all')) {
+      return columns;
+    }
+    return columns.filter((column) =>
+      transformationDataType.includes(column.type[0].toLowerCase())
+    );
+  };
+
+  const columnsToDisplay: IHeaderNamesList[] = getColumnsToDisplay();
+
+  return (
+    <StyledTableContainer data-testid="column-table-parent">
+      {columnsToDisplay.length === 0 && (
+        <FlexWrapper>
+          <CenterAlignWrapper>
+            {NoDataSVG}
+            <SubHeadBoldFont component="p" data-testid="no-column-title">
+              {T.translate(`${SELECT_COLUMN_LIST_PREFIX}.noColumns`)}
+            </SubHeadBoldFont>
+            <NormalFont component="p" data-testid="no-column-subTitle">
+              {T.translate(`${SELECT_COLUMN_LIST_PREFIX}.noMatchColumnDatatype`)}
+            </NormalFont>
+          </CenterAlignWrapper>
+        </FlexWrapper>
+      )}
+      {columnsToDisplay.length > 0 && (
+        <StyledTable aria-label="recipe steps table">
+          <Divider />
+          <StyledTableHead>
+            <StyledTableRow>
+              <StyledTableHeadCell>
+                {MULTI_SELECTION_COLUMN.findIndex((option) => option.value === transformationName) >
+                  -1 && (
+                  <Checkbox
+                    color="primary"
+                    checked={selectedColumns.length ? true : false}
+                    onChange={handleChange}
+                    indeterminate={selectedColumns.length ? true : false}
+                    data-testid="column-table-check-box"
+                    aria-checked="true"
+                  />
+                )}
+              </StyledTableHeadCell>
+              <StyledTableHeadCell data-testid="panel-columns">
+                {T.translate(`${ADD_TRANSFORMATION_PREFIX}.columns`)}
+                {` (${columns.length})`}
+              </StyledTableHeadCell>
+              <StyledTableHeadCell data-testid="panel-values">
+                {T.translate(`${ADD_TRANSFORMATION_PREFIX}.nullValues`)}
+              </StyledTableHeadCell>
+            </StyledTableRow>
+          </StyledTableHead>
+          <Divider />
+          <TableBody>
+            {columnsToDisplay.map((eachColumn, columnIndex) => (
+              <TableRowWidget
+                handleSingleSelection={handleSingleSelection}
+                selectedColumns={selectedColumns}
+                dataQualityValue={dataQualityValue}
+                isSingleSelection={isSingleSelection}
+                handleDisableCheckbox={handleDisableCheckbox}
+                handleMultipleSelection={handleMultipleSelection}
+                columnIndex={columnIndex}
+                columnDetail={eachColumn}
+              />
+            ))}
+          </TableBody>
+        </StyledTable>
+      )}
+    </StyledTableContainer>
+  );
+}

--- a/app/cdap/components/WranglerGrid/SelectColumnPanel/DataTable/types.ts
+++ b/app/cdap/components/WranglerGrid/SelectColumnPanel/DataTable/types.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import React, { ChangeEvent } from 'react';
+import { IHeaderNamesList } from 'components/WranglerGrid/SelectColumnPanel/types';
+import { Dispatch, SetStateAction } from 'react';
+
+interface ICommonInputProps {
+  handleSingleSelection: (value: IHeaderNamesList) => void;
+  handleDisableCheckbox: () => boolean;
+  handleMultipleSelection: (event: ChangeEvent<HTMLInputElement>, value: IHeaderNamesList) => void;
+  isSingleSelection: boolean;
+  selectedColumns: IHeaderNamesList[];
+}
+
+export interface IDataTableProps extends ICommonInputProps {
+  columns: IHeaderNamesList[];
+  transformationDataType: string[];
+  dataQualityValue: Array<Record<string, string | number>>;
+  totalColumnCount: number;
+  setSelectedColumns: Dispatch<SetStateAction<IHeaderNamesList[]>>;
+  transformationName: string;
+}
+
+export interface ITableRowWidgetProps extends ICommonInputProps {
+  dataQualityValue: Array<Record<string, string | number>>;
+  columnIndex: number;
+  columnDetail: IHeaderNamesList;
+}
+
+export interface IInputWidgetsProps extends ICommonInputProps {
+  columnDetail: IHeaderNamesList;
+  columnIndex: number;
+}

--- a/app/cdap/components/WranglerGrid/SelectColumnPanel/DrawerHeader/__test__/DrawerHeader.test.tsx
+++ b/app/cdap/components/WranglerGrid/SelectColumnPanel/DrawerHeader/__test__/DrawerHeader.test.tsx
@@ -1,0 +1,54 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import { fireEvent, render, screen } from '@testing-library/react';
+import React from 'react';
+import T from 'i18n-react';
+import DrawerHeader from 'components/WranglerGrid/SelectColumnPanel/DrawerHeader';
+
+describe('It should test DrawerHeader Component', () => {
+  it('Should test single selection column heading component', () => {
+    render(<DrawerHeader closeClickHandler={jest.fn()} isSingleSelection={true} />);
+    const headingElement = screen.getByTestId(/drawer-heading/i);
+    expect(headingElement).toHaveTextContent(
+      `${T.translate('features.WranglerNewUI.GridPage.addTransformationPanel.selectColumnHeading')}`
+    );
+  });
+
+  it('Should test multiple selection column heading component', () => {
+    render(<DrawerHeader closeClickHandler={jest.fn()} isSingleSelection={false} />);
+    const headingElement = screen.getByTestId(/drawer-heading/i);
+    expect(headingElement).toHaveTextContent(
+      `${T.translate(
+        'features.WranglerNewUI.GridPage.addTransformationPanel.selectMultiColumnsHeading'
+      )}`
+    );
+  });
+
+  it('Should trigger close button of panel', () => {
+    render(<DrawerHeader closeClickHandler={jest.fn()} isSingleSelection={false} />);
+    const closeButton = screen.getByTestId(/select-column-drawer-close-icon-button/i);
+    fireEvent.click(closeButton);
+    expect(closeButton).toBeInTheDocument();
+  });
+
+  it('Should trigger back button of panel', () => {
+    render(<DrawerHeader closeClickHandler={jest.fn()} isSingleSelection={false} />);
+    const backButton = screen.getByTestId(/back-icon-button/i);
+    fireEvent.click(backButton);
+    expect(backButton).toBeInTheDocument();
+  });
+});

--- a/app/cdap/components/WranglerGrid/SelectColumnPanel/DrawerHeader/index.tsx
+++ b/app/cdap/components/WranglerGrid/SelectColumnPanel/DrawerHeader/index.tsx
@@ -1,0 +1,108 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import { Box, Container, IconButton } from '@material-ui/core';
+import React from 'react';
+import CloseRoundedIcon from '@material-ui/icons/CloseRounded';
+import styled from 'styled-components';
+import { FlexAlignCenter } from 'components/common/BoxContainer';
+import { HeadFont } from 'components/common/TypographyText';
+import T from 'i18n-react';
+import { ADD_TRANSFORMATION_PREFIX } from 'components/WranglerGrid/SelectColumnPanel/constants';
+import grey from '@material-ui/core/colors/grey';
+import ChevronLeftRoundedIcon from '@material-ui/icons/ChevronLeftRounded';
+import { Underline } from 'components/common/DrawerWidget/IconStore/Underline';
+
+interface IDrawerHeaderProps {
+  closeClickHandler: () => void;
+  isSingleSelection: boolean;
+}
+
+const BackIcon = styled(ChevronLeftRoundedIcon)`
+  font-size: 40px;
+  color: ${grey[600]};
+`;
+
+const DrawerContainerInnerFlex = styled(Box)`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-top: 15px;
+`;
+
+const DrawerHeadWrapper = styled(Box)`
+  display: flex;
+  flex-direction: column;
+`;
+
+const FlexWrapper = styled(Box)`
+  display: flex;
+`;
+
+const StyledIconButton = styled(IconButton)`
+  padding: 0px;
+  width: 26px;
+  justify-content: end;
+  &.MuiIconButton-root:hover {
+    background-color: transparent;
+  }
+  & .MuiTouchRipple-root {
+    display: none;
+  }
+`;
+
+const Wrapper = styled(Container)`
+  padding-left: 0;
+  padding-right: 0;
+`;
+
+export default function({ closeClickHandler, isSingleSelection }: IDrawerHeaderProps) {
+  return (
+    <Wrapper data-testid="select-column-drawer">
+      <DrawerContainerInnerFlex>
+        <FlexAlignCenter>
+          <StyledIconButton
+            onClick={closeClickHandler}
+            aria-label="back-icon"
+            data-testid="back-icon-button"
+          >
+            <BackIcon />
+          </StyledIconButton>
+          <DrawerHeadWrapper>
+            <HeadFont component="p" data-testid="drawer-heading">
+              {isSingleSelection && T.translate(`${ADD_TRANSFORMATION_PREFIX}.selectColumnHeading`)}
+              {!isSingleSelection &&
+                T.translate(`${ADD_TRANSFORMATION_PREFIX}.selectMultiColumnsHeading`)}
+            </HeadFont>
+            {Underline()}
+          </DrawerHeadWrapper>
+        </FlexAlignCenter>
+        <FlexWrapper>
+          <StyledIconButton
+            data-testid="select-column-drawer-close-icon-button"
+            onClick={closeClickHandler}
+          >
+            <CloseRoundedIcon
+              color="action"
+              fontSize="large"
+              data-testid="select-column-drawer-close-icon"
+            />
+          </StyledIconButton>
+        </FlexWrapper>
+      </DrawerContainerInnerFlex>
+    </Wrapper>
+  );
+}

--- a/app/cdap/components/WranglerGrid/SelectColumnPanel/__tests__/AddTransformation.test.tsx
+++ b/app/cdap/components/WranglerGrid/SelectColumnPanel/__tests__/AddTransformation.test.tsx
@@ -1,0 +1,47 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import { fireEvent, render, screen } from '@testing-library/react';
+import history from 'services/history';
+import React from 'react';
+import { Route, Router, Switch } from 'react-router';
+import SelectColumn from 'components/WranglerGrid/SelectColumnPanel';
+
+describe('It should test the SelectColumnsList Component', () => {
+  it('should render the SelectColumnsList Component where transformationName=is parseCSV and click on close button', () => {
+    const mockCancelFunction = jest.fn();
+    render(
+      <Router history={history}>
+        <Switch>
+          <Route>
+            <SelectColumn
+              transformationName="parseCSV"
+              transformationDataType={[]}
+              columnsList={[]}
+              missingItemsList={undefined}
+              onCancel={mockCancelFunction}
+            />
+          </Route>
+        </Switch>
+      </Router>
+    );
+    expect(screen.getByTestId(/select-column-panel/i)).toBeInTheDocument();
+
+    const closeButton = screen.getByTestId(/select-column-drawer-close-icon-button/i);
+    fireEvent.click(closeButton);
+    expect(mockCancelFunction).toBeCalled();
+  });
+});

--- a/app/cdap/components/WranglerGrid/SelectColumnPanel/constants.ts
+++ b/app/cdap/components/WranglerGrid/SelectColumnPanel/constants.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import { IMultipleSelectedFunctionDetail } from 'components/WranglerGrid/SelectColumnPanel/types';
+
+export const MULTI_SELECTION_COLUMN: IMultipleSelectedFunctionDetail[] = [
+  {
+    value: 'join-columns',
+    isMoreThanTwo: false,
+  },
+  {
+    value: 'swap-columns',
+    isMoreThanTwo: false,
+  },
+  {
+    value: 'delete',
+    isMoreThanTwo: true,
+  },
+  {
+    value: 'array-flattening',
+    isMoreThanTwo: true,
+  },
+  {
+    value: 'record-flattening',
+    isMoreThanTwo: true,
+  },
+  {
+    value: 'keep',
+    isMoreThanTwo: true,
+  },
+];
+
+export const SELECT_COLUMN_LIST_PREFIX = 'features.WranglerNewUI.GridPage.selectColumnListPanel';
+export const ADD_TRANSFORMATION_PREFIX = 'features.WranglerNewUI.GridPage.addTransformationPanel';

--- a/app/cdap/components/WranglerGrid/SelectColumnPanel/index.tsx
+++ b/app/cdap/components/WranglerGrid/SelectColumnPanel/index.tsx
@@ -1,0 +1,123 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import T from 'i18n-react';
+import React, { useState, useEffect } from 'react';
+import ColumnsList from 'components/WranglerGrid/SelectColumnPanel/ColumnsList';
+import {
+  IAddTransformationProps,
+  IHeaderNamesList,
+} from 'components/WranglerGrid/SelectColumnPanel/types';
+import { getDataQuality } from 'components/common/DataQualityCircularProgressBar/utils';
+import { ADD_TRANSFORMATION_PREFIX } from 'components/WranglerGrid/SelectColumnPanel/constants';
+import {
+  AddTransformationBodyWrapper,
+  AddTransformationWrapper,
+} from 'components/common/BoxContainer';
+import { AddTransformationButton } from 'components/common/ButtonWidget';
+import styled from 'styled-components';
+import { Container, Drawer } from '@material-ui/core';
+import {
+  enableDoneButton,
+  getFilteredColumn,
+  getIsSingleSelectionCheck,
+} from 'components/WranglerGrid/SelectColumnPanel/utils';
+import DrawerHeader from 'components/WranglerGrid/SelectColumnPanel/DrawerHeader';
+
+export const DrawerContainer = styled(Container)`
+  width: 500px;
+  height: 100%;
+  padding-left: 30px;
+`;
+
+export const StyledDrawer = styled(Drawer)`
+  & .MuiDrawer-paper {
+    top: 46px;
+    height: calc(100vh - 47px);
+  }
+`;
+
+export default function({
+  transformationDataType,
+  transformationName,
+  columnsList,
+  missingItemsList,
+  onCancel,
+}: IAddTransformationProps) {
+  const [columnsPopup, setColumnsPopup] = useState(true);
+  const [selectedColumns, setSelectedColumns] = useState<IHeaderNamesList[]>([]);
+  const [dataQualityValue, setDataQualityValue] = useState<Array<Record<string, string | number>>>(
+    []
+  );
+  const filteredColumnsOnTransformationType: IHeaderNamesList[] = getFilteredColumn(
+    transformationDataType,
+    columnsList
+  );
+  const isSingleSelection = getIsSingleSelectionCheck(transformationName);
+
+  const closeSelectColumnsPopup = () => {
+    setColumnsPopup(false);
+    onCancel();
+  };
+
+  const closeSelectColumnsPopupWithoutColumn = () => {
+    setColumnsPopup(false);
+    setSelectedColumns([]);
+    onCancel();
+  };
+
+  useEffect(() => {
+    const getPreparedDataQuality: Array<Record<string, string | number>> = getDataQuality(
+      missingItemsList,
+      columnsList
+    );
+    setDataQualityValue(getPreparedDataQuality);
+  }, []);
+
+  return (
+    <StyledDrawer open={columnsPopup} data-testid="select-column-panel" anchor="right">
+      <DrawerContainer data-testid="select-column-drawer">
+        <DrawerHeader
+          closeClickHandler={closeSelectColumnsPopupWithoutColumn}
+          isSingleSelection={isSingleSelection}
+        />
+        <AddTransformationWrapper>
+          <AddTransformationBodyWrapper>
+            <ColumnsList
+              columnsList={columnsList}
+              selectedColumnsCount={selectedColumns.length}
+              setSelectedColumns={setSelectedColumns}
+              dataQuality={dataQualityValue}
+              transformationDataType={transformationDataType}
+              transformationName={transformationName}
+              selectedColumns={selectedColumns}
+              filteredColumnsOnTransformationType={filteredColumnsOnTransformationType}
+              isSingleSelection={isSingleSelection}
+            />
+          </AddTransformationBodyWrapper>
+          <AddTransformationButton
+            disabled={enableDoneButton(transformationName, selectedColumns)}
+            color="primary"
+            data-testid="button-done"
+            onClick={closeSelectColumnsPopup}
+          >
+            {T.translate(`${ADD_TRANSFORMATION_PREFIX}.done`)}
+          </AddTransformationButton>
+        </AddTransformationWrapper>
+      </DrawerContainer>
+    </StyledDrawer>
+  );
+}

--- a/app/cdap/components/WranglerGrid/SelectColumnPanel/types.ts
+++ b/app/cdap/components/WranglerGrid/SelectColumnPanel/types.ts
@@ -1,0 +1,51 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import { IGeneralStatistics, IParams } from 'components/GridTable/types';
+
+export interface IRecords {
+  wid?: string;
+  payload?: IParams;
+  body?: string;
+  path?: string;
+  canBrowse?: boolean;
+  name?: string;
+}
+
+export interface IHeaderNamesList {
+  name: string;
+  label: string;
+  type: string[];
+}
+
+export interface IAddTransformationProps {
+  transformationDataType: string[];
+  transformationName: string;
+  columnsList: IHeaderNamesList[];
+  missingItemsList: Record<string, IGeneralStatistics>;
+  onCancel: () => void;
+}
+
+export interface IMultipleSelectedFunctionDetail {
+  value:
+    | 'join-columns'
+    | 'swap-columns'
+    | 'delete'
+    | 'array-flattening'
+    | 'record-flattening'
+    | 'keep';
+  isMoreThanTwo: boolean;
+}

--- a/app/cdap/components/WranglerGrid/SelectColumnPanel/utils.ts
+++ b/app/cdap/components/WranglerGrid/SelectColumnPanel/utils.ts
@@ -1,0 +1,86 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import {
+  IHeaderNamesList,
+  IMultipleSelectedFunctionDetail,
+} from 'components/WranglerGrid/SelectColumnPanel/types';
+import { MULTI_SELECTION_COLUMN } from 'components/WranglerGrid/SelectColumnPanel/constants';
+
+/**
+ * @param  {string[]} transformationDataType
+ * @param  {IHeaderNamesList[]} columnsList
+ * @return {IHeaderNamesList[]} This function is used to return the list of column based on the transformation/option selected
+ * For Example ADD, this can be performed on column whose datatype is int/float/double so this function will return only those
+ * columns whose dataype int/float/double
+ */
+export const getFilteredColumn = (
+  transformationDataType: string[],
+  columnsList: IHeaderNamesList[]
+) => {
+  if (transformationDataType.length && transformationDataType.includes('all')) {
+    return columnsList;
+  } else {
+    const filteredColumnList = columnsList.filter((columnDetail: IHeaderNamesList) => {
+      return transformationDataType.some((dataTypeCollection: string) => {
+        return dataTypeCollection.includes(columnDetail.type[0].toLowerCase());
+      });
+    });
+    return filteredColumnList;
+  }
+};
+
+/**
+ * @param  {string} transformationName
+ * @param  {IHeaderNamesList[]} selectedColumns
+ * @return {boolean} This function is used to enable done button which can be enabled only when atleast one column is selected
+ * In case of join and swap two column needs to be selected while in delete/keep more than two selections are posible
+ */
+export const enableDoneButton = (
+  transformationName: string,
+  selectedColumns: IHeaderNamesList[]
+) => {
+  const indexForTwoColumnSelection = MULTI_SELECTION_COLUMN.findIndex(
+    (functionNameDetail: IMultipleSelectedFunctionDetail) =>
+      functionNameDetail.value === transformationName && !functionNameDetail.isMoreThanTwo
+  );
+  const indexForMultipleColumnSelection = MULTI_SELECTION_COLUMN.findIndex(
+    (functionNameDetail: IMultipleSelectedFunctionDetail) =>
+      functionNameDetail.value === transformationName && functionNameDetail.isMoreThanTwo
+  );
+  if (indexForTwoColumnSelection > -1) {
+    return selectedColumns.length !== 2; // implies that the button should be enabled on when two columns are selected
+  } else if (indexForMultipleColumnSelection > -1) {
+    return !(selectedColumns.length >= 1); // implies that even if one column is selected the button should be enabled (more than two column selection)
+  } else {
+    return !(selectedColumns.length >= 1); // implies case of single selection of radio button only one needs to be selected to enable button
+  }
+};
+
+/**
+ * @param  {string} transformationName
+ * @return {boolean} This function is used to check whether transformation selected can be applied on single column or multiple column can be selected
+ */
+export const getIsSingleSelectionCheck = (transformationName: string) => {
+  const indexOfSingleSelection = MULTI_SELECTION_COLUMN.findIndex(
+    (functionDetail: IMultipleSelectedFunctionDetail) =>
+      functionDetail.value.toLowerCase() === transformationName.toLowerCase()
+  );
+  if (indexOfSingleSelection > -1) {
+    return false;
+  }
+  return true;
+};


### PR DESCRIPTION
External PR Link:
https://github.com/cdapio/cdap-ui/pull/789

# TITLE
Feature - Select Column Panel

## Description
Summary of changes
This PR contains the changes related to Select Column Panel

## PR Type
- [ ] Bug Fix
- [x] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement
- [ ] Cherry Pick

## Links
Jira: [Jira issue #](fill-in.org)
https://cdap.atlassian.net/browse/CDAP-19704

## Following are the files to be reviewed
1. app/cdap/components/WranglerGrid/SelectColumnPanel/*
2. app/cdap/components/common/*
4. app/cdap/text/text-en.yaml
5. src/e2e-test/*
6. package.json

## Test Plan
1. FE_36_172 - Verify whether the Select column panel window is displayed as per Figma or not - Pass
2. FE_36_173 - Verify the "Select column(s) to apply this function" text is displayed as a title or not. - Pass
3. FE_36_174 - Verify the "Back arrow icon" on the left side of the select column panel is displayed or not. - Pass
4. FE_36_175 - Verify the "Back arrow icon" by mouse hovering - Pass
5. FE_36_176 - Verify by clicking on the "Back arrow" icon - Pass
6. FE_36_177 - Verify whether the checkbox icon is displayed or not besides the "Columns with no. count" when the tabular column has Radio Buttons. - Pass
7. FE_36_178 - Verify the "Done button" is enabled or not, after selecting from any of the sub navigations (ex: Integer, long, short, etc) - Pass
8. FE_36_179 - Verify the "Close icon" on the right side of the select column panel is displayed or not. - Pass
9. FE_36_180 - Verify the "Search icon" on the right side of the No columns selected(Updated text) text is matched with Figma or not. - Pass
10. FE_36_181 - Verify the "Search icon" on the right side of the No columns selected text by mouse hovering - Pass
11. FE_36_182 - Verify by clicking on the "Search" icon - Pass
12. FE_36_183 - Verify the "Search" field by editing - Pass
13. FE_36_184 - Verify by selecting from the entered text is displaying in the editable text field or not. - Pass
14. FE_36_185 - Verify the "horizontal column with Columns & Null Values text" are as per design or not. - Pass
15. FE_36_186 - Verify the count NO. is displayed beside the columns text sections. - Pass
16. FE_36_187 - Verify whether the null values column is displayed with the percentage progress graph as per Figma or not. - Pass
17. FE_36_188 - Verify the Vertical scroll bar is automatically updated with the increase of sections/columns. - Pass
18. FE_36_189 - Verify that after selecting on "string" type from the sub-navigation, what type of function (ex: checkbox/Radio buttons) is displayed. - Pass
19. FE_36_190 - Verify whether the "Done button" is enabled or not after selecting on "string" type. - Pass
20. FE_36_191 - Verify that after selecting on "Boolean" type from the sub-navigation, what type of function (ex: checkbox/Radio buttons) is displayed. - Pass
21. FE_36_192 - Verify whether the "Done button" is enabled or not, after selecting on "Boolean" type. - Pass
22. FE_36_193 - Verify whether the checkbox icon is displayed or not besides the "Columns with no. count" when the tabular column has check boxes. - Pass
23. FE_36_194 - Verify the checkbox beside the "Columns with no. count" is selected or not after selecting the checkboxes function from the table row of the "String or Boolean" type sub-navigation. - Pass
24. FE_36_195 - Verify that after selecting from the sub-navigation (ex: Integer, long, short, etc), what type of function (ex: checkbox/Radio buttons) is displayed. - Pass
25. FE_36_196 - Verify whether the checkbox icon is displayed or not besides the "Columns with no. count" when the tabular column has Radio Buttons. - Pass
26. FE_36_197 - Verify the "Done button" is enabled or not, after selecting from any of the sub navigations (ex: Integer, long, short, etc) - Pass
27. FE_36_198 - Verify the "Close icon" on the right side of the select column panel is displayed or not. - Pass
28. FE_36_199 - Verify the "Close icon" by mouse hovering - Pass
29. FE_36_200 - Verify by clicking on the "Close" icon - Pass
30. FE_36_201 - Verify the redirection after clicking on the "Close" icon - Pass

## Screenshots
1. Single Column Transformations (Radio Buttons)
<img width="627" alt="Screenshot 2022-11-17 at 11 22 17 PM" src="https://user-images.githubusercontent.com/61772422/202534012-c6b1f107-6fbc-45c0-9b30-2c93533f5858.png">

2. Single Column Transformations (Radio Buttons) - 1 Column Selected
<img width="752" alt="Screenshot 2022-11-17 at 11 22 44 PM" src="https://user-images.githubusercontent.com/61772422/202534127-9f34ca87-54a4-4b17-85fe-be09c11dfe75.png">

3. Multi-Column Transformations (Checkboxes)
<img width="744" alt="Screenshot 2022-11-17 at 11 30 28 PM" src="https://user-images.githubusercontent.com/61772422/202534155-7e5b4bb9-1d08-46b6-8251-9865d79a4a7e.png">

4. Two-Column Transformations (Checkboxes) - 2 Columns Selected
<img width="764" alt="Screenshot 2022-11-17 at 11 30 51 PM" src="https://user-images.githubusercontent.com/61772422/202534214-0318a522-1f27-4439-894c-fbac0c3239a4.png">

5. Multi-Column Transformations (Checkboxes) - 4 Columns Selected
<img width="762" alt="Screenshot 2022-11-17 at 11 47 25 PM" src="https://user-images.githubusercontent.com/61772422/202534285-f6f537a5-7a15-48ed-8a27-67aedbf0435d.png">
